### PR TITLE
Standardize Getters/Setters on ThingI

### DIFF
--- a/src/main/java/ure/actions/ActionDrop.java
+++ b/src/main/java/ure/actions/ActionDrop.java
@@ -18,7 +18,7 @@ public class ActionDrop extends UAction {
     public ActionDrop(UActor theactor, UThing thething) {
         actor = theactor;
         thing = thething;
-        destination = actor.location();
+        destination = actor.getLocation();
     }
     public ActionDrop(UActor theactor, UThing thething, UContainer thedest) {
         actor = theactor;
@@ -30,7 +30,7 @@ public class ActionDrop extends UAction {
     void doMe() {
         if (thing != null) {
             if (destination == null) {
-                destination = actor.location();
+                destination = actor.getLocation();
             }
             if (!actor.tryDropThing(thing, destination))
                 suppressEvent();

--- a/src/main/java/ure/actions/ActionGet.java
+++ b/src/main/java/ure/actions/ActionGet.java
@@ -1,6 +1,7 @@
 package ure.actions;
 
 import ure.actors.UActor;
+import ure.actors.UPlayer;
 import ure.things.UThing;
 
 /**
@@ -30,7 +31,7 @@ public class ActionGet extends UAction {
         if (thing == null) {
             thing = actor.myCell().topThingAt();
             if (thing == null) {
-                if (actor.isPlayer()) {
+                if (actor instanceof UPlayer) {
                     commander.printScroll(nothingToGetMsg);
                 }
             }

--- a/src/main/java/ure/actors/UActor.java
+++ b/src/main/java/ure/actors/UActor.java
@@ -1,11 +1,9 @@
 package ure.actors;
 
-import ure.*;
 import ure.actions.Interactable;
 import ure.actions.UAction;
 import ure.areas.UArea;
 import ure.areas.UCell;
-import ure.areas.ULandscaper;
 import ure.math.UPath;
 import ure.terrain.UTerrain;
 import ure.things.Lightsource;
@@ -30,7 +28,6 @@ public class UActor extends ThingI implements Interactable {
 
     public UCamera camera;
     int cameraPinStyle;
-    UPath path;
 
     int moveAnimX = 0;
     int moveAnimY = 0;
@@ -45,7 +42,6 @@ public class UActor extends ThingI implements Interactable {
     public void initialize() {
         super.initialize();
         glyphOutline = true;
-        path = new UPath();
     }
 
     @Override

--- a/src/main/java/ure/actors/UActor.java
+++ b/src/main/java/ure/actors/UActor.java
@@ -36,17 +36,10 @@ public class UActor extends ThingI implements Interactable {
 
     float actionTime = 0f;
 
-    public static boolean isActor = true;
-
     @Override
     public void initialize() {
         super.initialize();
-        glyphOutline = true;
-    }
-
-    @Override
-    public boolean isActor() {
-        return true;
+        setGlyphOutline(true);
     }
 
     public float actionTime() {
@@ -71,7 +64,7 @@ public class UActor extends ThingI implements Interactable {
     public void walkDir(int xdir, int ydir) {
         int destX = xdir + areaX();
         int destY = ydir + areaY();
-        if (location.containerType() == UContainer.TYPE_CELL) {
+        if (getLocation().containerType() == UContainer.TYPE_CELL) {
             if (!myTerrain().preventMoveFrom(this)) {
                 if (area().isValidXY(destX, destY)) {
                     area().cellAt(destX, destY).moveTriggerFrom(this);
@@ -89,7 +82,7 @@ public class UActor extends ThingI implements Interactable {
 
     @Override
     public boolean drawGlyphOutline() {
-        if (glyphOutline)
+        if (isGlyphOutline())
             return true;
         if (commander.config.isOutlineActors())
             return true;
@@ -136,7 +129,7 @@ public class UActor extends ThingI implements Interactable {
         int oldx = -1;
         int oldy = -1;
         UArea oldarea = null;
-        if (location != null) {
+        if (getLocation() != null) {
             oldx = areaX();
             oldy = areaY();
             oldarea = area();
@@ -158,9 +151,8 @@ public class UActor extends ThingI implements Interactable {
             }
         }
         int moveFrames = commander.config.getMoveAnimFrames();
-        if (isPlayer()) moveFrames = commander.config.getMoveAnimPlayerFrames();
+        if (this instanceof UPlayer) moveFrames = commander.config.getMoveAnimPlayerFrames();
         if (oldx >=0 && oldarea == thearea && moveFrames > 0) {
-            int frames =
             moveAnimX = (oldx-destX)*commander.config.getGlyphWidth();
             moveAnimY = (oldy-destY)*commander.config.getGlyphHeight();
             moveAnimDX = -(moveAnimX / moveFrames);
@@ -170,8 +162,8 @@ public class UActor extends ThingI implements Interactable {
     }
 
     public UCell myCell() {
-        if (location.containerType() == UContainer.TYPE_CELL)
-            return (UCell)location;
+        if (getLocation().containerType() == UContainer.TYPE_CELL)
+            return (UCell) getLocation();
         return null;
     }
     public void debug() {
@@ -182,7 +174,7 @@ public class UActor extends ThingI implements Interactable {
   }
 
     public void moveTriggerFrom(UActor actor) {
-        if (actor.isPlayer())
+        if (actor instanceof UPlayer)
             commander.printScroll("Ow!");
     }
 
@@ -194,10 +186,10 @@ public class UActor extends ThingI implements Interactable {
         }
         if (thing.tryGetBy(this)) {
             thing.moveTo(this);
-            if (isPlayer())
-                commander.printScroll("You pick up " + thing.iname() + ".");
+            if (this instanceof UPlayer)
+                commander.printScroll("You pick up " + thing.getIname() + ".");
             else
-                commander.printScrollIfSeen(this, this.dnamec() + " picks up " + thing.iname() + ".");
+                commander.printScrollIfSeen(this, this.getDnamec() + " picks up " + thing.getIname() + ".");
             thing.gotBy(this);
             return true;
         }
@@ -211,10 +203,10 @@ public class UActor extends ThingI implements Interactable {
         }
         if (dest.willAcceptThing(thing)) {
             thing.moveTo(dest);
-            if (isPlayer())
-                commander.printScroll("You drop " + thing.iname() + ".");
+            if (this instanceof UPlayer)
+                commander.printScroll("You drop " + thing.getIname() + ".");
             else
-                commander.printScrollIfSeen(this, this.dnamec() + " drops " + thing.iname() + ".");
+                commander.printScrollIfSeen(this, this.getDnamec() + " drops " + thing.getIname() + ".");
             thing.droppedBy(this);
             return true;
         }
@@ -237,12 +229,12 @@ public class UActor extends ThingI implements Interactable {
     public void startActing() {
             commander.registerActor(this);
             awake = true;
-            System.out.println(this.name + ": waking up!");
+            System.out.println(this.getName() + ": waking up!");
     }
     public void stopActing() {
         commander.unregisterActor(this);
         awake = false;
-        System.out.println(this.name + ": going to sleep.");
+        System.out.println(this.getName() + ": going to sleep.");
     }
 
     public void act() {
@@ -279,7 +271,7 @@ public class UActor extends ThingI implements Interactable {
     }
 
     public void wakeCheck(int playerx, int playery) {
-        if (location == null) return;
+        if (getLocation() == null) return;
         int dist = Math.abs(areaX() - playerx) + Math.abs(areaY() - playery);
         if (awake && (sleeprange > 0) && (dist > sleeprange)) {
             stopActing();

--- a/src/main/java/ure/actors/UActorCzar.java
+++ b/src/main/java/ure/actors/UActorCzar.java
@@ -27,7 +27,7 @@ public class UActorCzar {
             UActor[] actorObjs = objectMapper.readValue(inputStream, UActor[].class);
             for (UActor actor: actorObjs) {
                 actor.initialize();
-                actorsByName.put(actor.name, actor);
+                actorsByName.put(actor.getName(), actor);
             }
         } catch (IOException io) {
             io.printStackTrace();

--- a/src/main/java/ure/actors/UNPC.java
+++ b/src/main/java/ure/actors/UNPC.java
@@ -5,6 +5,7 @@ import ure.actions.UAction;
 import ure.actions.ActionGet;
 import ure.actions.ActionWalk;
 import ure.behaviors.UBehavior;
+import ure.math.UPath;
 import ure.ui.modals.UModal;
 import ure.ui.modals.UModalNotify;
 
@@ -50,7 +51,7 @@ public class UNPC extends UActor {
     public void hearEvent(UAction action) {
         if (action.actor != this) {
             if (action instanceof ActionGet) {
-                emote(dnamec() + " says, \"Hey that's mine!\"");
+                emote(getDnamec() + " says, \"Hey that's mine!\"");
             }
         }
     }
@@ -87,8 +88,8 @@ public class UNPC extends UActor {
         return new ActionWalk(this,wx,wy);
     }
     UAction HuntPlayer() {
-        System.out.println(this.name + " hunting from " + Integer.toString(areaX()) + "," + Integer.toString(areaY()));
-        int[] step = path.nextStep(area(), areaX(), areaY(), commander.player().areaX(), commander.player().areaY(), this, 25);
+        System.out.println(this.getName() + " hunting from " + Integer.toString(areaX()) + "," + Integer.toString(areaY()));
+        int[] step = UPath.nextStep(area(), areaX(), areaY(), commander.player().areaX(), commander.player().areaY(), this, 25);
         if (step != null) {
             return new ActionWalk(this,step[0] - areaX(), step[1] - areaY());
         }

--- a/src/main/java/ure/actors/UPlayer.java
+++ b/src/main/java/ure/actors/UPlayer.java
@@ -14,8 +14,6 @@ public class UPlayer extends UActor {
 
     public boolean awake = true;
 
-    public static boolean isActor = true;
-
     ULight light;
 
     public UPlayer(String thename, char theicon, UColor thecolor, boolean addOutline, UColor selfLightColor, int selfLight, int selfLightFalloff) {
@@ -26,9 +24,6 @@ public class UPlayer extends UActor {
             light = new ULight(selfLightColor, selfLightFalloff + selfLight, selfLight);
         }
     }
-
-    @Override
-    public boolean isPlayer() { return true; }
 
     @Override
     public void moveToCell(UArea area, int destX, int destY) {

--- a/src/main/java/ure/areas/UArea.java
+++ b/src/main/java/ure/areas/UArea.java
@@ -1,5 +1,6 @@
 package ure.areas;
 
+import ure.actors.UPlayer;
 import ure.sys.Injector;
 import ure.sys.UCommander;
 import ure.actions.UAction;
@@ -192,7 +193,7 @@ public class UArea implements UTimeListener, Serializable {
     public boolean hasTerrainAt(int x, int y, String terrain) {
         if (isValidXY(x,y))
             if (cells[x][y] != null)
-                if (cells[x][y].terrain.name().equals(terrain))
+                if (cells[x][y].terrain.getName().equals(terrain))
                     return true;
         return false;
     }
@@ -256,9 +257,9 @@ public class UArea implements UTimeListener, Serializable {
      * @return
      */
     public void addedThing(UThing thing, int x, int y) {
-        if (thing.isActor()) {
+        if (thing instanceof UActor) {
             actors.add((UActor) thing);
-            if (((UActor) thing).isPlayer()) {
+            if (thing instanceof UPlayer) {
                 wakeCheckAll(x,y);
             } else {
                 ((UActor)thing).wakeCheck(x,y);

--- a/src/main/java/ure/areas/UCell.java
+++ b/src/main/java/ure/areas/UCell.java
@@ -1,5 +1,6 @@
 package ure.areas;
 
+import ure.actors.UPlayer;
 import ure.sys.Injector;
 import ure.sys.UCommander;
 import ure.actions.UAction;
@@ -76,7 +77,7 @@ public class UCell implements UContainer {
     }
 
     public void walkedOnBy(UActor actor) {
-        if (actor.isPlayer() && contents.hasThings()) {
+        if (actor instanceof UPlayer && contents.hasThings()) {
             UThing thing = contents.topThing();
             commander.printScroll(thing.walkMsg(actor));
         }
@@ -130,7 +131,7 @@ public class UCell implements UContainer {
      */
     public boolean hasA(String thing) {
         for (UThing t : contents.things) {
-            if (t.name().equals(thing))
+            if (t.getName().equals(thing))
                 return true;
         }
         return false;

--- a/src/main/java/ure/areas/ULandscaper.java
+++ b/src/main/java/ure/areas/ULandscaper.java
@@ -239,7 +239,7 @@ public class ULandscaper {
     boolean cellHasTerrain(UArea area, UCell cell, String[] terrains) {
         if (cell == null) return false;
         for (int i=0;i<terrains.length;i++) {
-            if (terrains[i].equals(cell.terrain.name())) {
+            if (terrains[i].equals(cell.terrain.getName())) {
                 return true;
             }
         }
@@ -418,7 +418,7 @@ public class ULandscaper {
         for (;x1<=x2;x1++) {
             for (;y1<=y2;y1++) {
                 if (area.isValidXY(x1,y1)) {
-                    String ts = area.terrainAt(x1,y1).name();
+                    String ts = area.terrainAt(x1,y1).getName();
                     for (String s : terrains) {
                         if (s.equals(ts))
                             return true;
@@ -432,7 +432,7 @@ public class ULandscaper {
     public String terrainNameAt(UArea area, int x, int y) {
         UCell cell = area.cellAt(x,y);
         if (cell != null) {
-            return cell.terrain().name();
+            return cell.terrain().getName();
         }
         return null;
     }

--- a/src/main/java/ure/commands/CommandDrop.java
+++ b/src/main/java/ure/commands/CommandDrop.java
@@ -22,7 +22,7 @@ public class CommandDrop extends UCommand implements HearModalEntityPick {
 
     @Override
     public void execute(UPlayer player) {
-        if (!player.contents().hasThings()) {
+        if (!player.getContents().hasThings()) {
             commander.printScroll(dropNothingMsg);
             return;
         }

--- a/src/main/java/ure/examplegame/ExampleCaveScaper.java
+++ b/src/main/java/ure/examplegame/ExampleCaveScaper.java
@@ -93,7 +93,7 @@ public class ExampleCaveScaper extends ULandscaper {
 
     @Override
     public void SetStairsLabel(UArea area, UCartographer carto, int x, int y, Stairs t) {
-        if (t.name().equals("cave exit")) {
+        if (t.getName().equals("cave exit")) {
             t.setLabel("forest", carto);
         } else {
             t.setLabel("cavern", carto);

--- a/src/main/java/ure/math/UPath.java
+++ b/src/main/java/ure/math/UPath.java
@@ -2,7 +2,6 @@ package ure.math;
 
 import ure.areas.UArea;
 import ure.actors.UActor;
-import ure.areas.UCell;
 import ure.things.UThing;
 
 import java.util.Comparator;
@@ -18,18 +17,15 @@ import java.util.TreeSet;
  */
 public class UPath {
 
-    Random random;
+    private static Random random = new Random();
 
-    public UPath() {
-        random = new Random();
-    }
-
-    class Nodelist extends TreeSet<Node> {
+    static class Nodelist extends TreeSet<Node> {
         public Nodelist() {
             super(new Node(0,0));
         }
     }
-    class Node implements Comparator<Node> {
+
+    static class Node implements Comparator<Node> {
         int x, y;
         Node parent;
         double g, h, f;
@@ -60,7 +56,7 @@ public class UPath {
         }
     }
 
-    public Node NodeIfOpen(UArea area, int x, int y, Node parent, UActor actor) {
+    public static Node NodeIfOpen(UArea area, int x, int y, Node parent, UActor actor) {
         if (x < 0 || y < 0 || x >= area.xsize || y >= area.ysize)
             return null;
         if (area.willAcceptThing((UThing)actor, x, y))
@@ -117,7 +113,7 @@ public class UPath {
      * @return (x,y) walk delta of next step
      *
      */
-    public int[] nextStep(UArea area, int x1, int y1, int x2, int y2, UActor actor, int range) {
+    public static int[] nextStep(UArea area, int x1, int y1, int x2, int y2, UActor actor, int range) {
         if (mdist(x1,y1,x2,y2) > range)
             return null;
         Nodelist openlist = new Nodelist();

--- a/src/main/java/ure/sys/Entity.java
+++ b/src/main/java/ure/sys/Entity.java
@@ -8,7 +8,7 @@ import ure.ui.Icon;
  */
 public interface Entity {
 
-    String name();
-    Icon icon();
+    String getName();
+    Icon getIcon();
     String[] UIdetails(String context);
 }

--- a/src/main/java/ure/terrain/Door.java
+++ b/src/main/java/ure/terrain/Door.java
@@ -39,11 +39,11 @@ public class Door extends TerrainI implements UTerrain {
     }
 
     @Override
-    public char glyph() {
+    public char getGlyph() {
         if (isOpen()) {
             return glyphopen;
         }
-        return super.glyph();
+        return super.getGlyph();
     }
     @Override
     public void moveTriggerFrom(UActor actor, UCell cell) {

--- a/src/main/java/ure/terrain/Lava.java
+++ b/src/main/java/ure/terrain/Lava.java
@@ -12,7 +12,7 @@ public class Lava extends TerrainI implements UTerrain {
     int bubbleFrames = 0;
 
     @Override
-    public char glyph() {
+    public char getGlyph() {
         if (bubbleFrames > 0) {
             bubbleFrames--;
             return '.';
@@ -20,11 +20,11 @@ public class Lava extends TerrainI implements UTerrain {
         Random r = new Random();
         if (r.nextFloat() > 0.9992)
             bubbleFrames = r.nextInt(60) + 8;
-        return super.glyph();
+        return super.getGlyph();
     }
 
     @Override
     public char glyph(int x, int y) {
-        return glyph();
+        return getGlyph();
     }
 }

--- a/src/main/java/ure/terrain/TerrainDeco.java
+++ b/src/main/java/ure/terrain/TerrainDeco.java
@@ -73,11 +73,10 @@ public class TerrainDeco implements UTerrain, Interactable, Entity {
     /**
      * Our 'normal' glyph.
      */
-    public char glyph() {
-
-        return terrain.glyph();
+    public char getGlyph() {
+        return terrain.getGlyph();
     }
-    public Icon icon() { return terrain.icon(); }
+    public Icon getIcon() { return terrain.getIcon(); }
     public String[] UIdetails(String context) { return terrain.UIdetails(context); }
 
     /**
@@ -189,9 +188,8 @@ public class TerrainDeco implements UTerrain, Interactable, Entity {
      * WARNING: URE uses the name to look up terrains internally.  Overriding this could make your system
      * more fragile.  Think about what you're doing.
      */
-    public String name() {
-
-        return terrain.name();
+    public String getName() {
+        return terrain.getName();
     }
     public String bonkmsg() { return terrain.bonkmsg(); }
 

--- a/src/main/java/ure/terrain/TerrainI.java
+++ b/src/main/java/ure/terrain/TerrainI.java
@@ -1,5 +1,6 @@
 package ure.terrain;
 
+import ure.actors.UPlayer;
 import ure.sys.Entity;
 import ure.sys.Injector;
 import ure.sys.UAnimator;
@@ -29,13 +30,13 @@ public abstract class TerrainI implements UTerrain, Entity, Cloneable, UAnimator
 
     public static final String TYPE = "";
 
-    public String name;
+    protected String name;
     public String type;
     public String walkmsg = "";
     public String bonkmsg = "";
     public char filechar;
-    public char glyph;
-    public Icon icon;
+    protected char glyph;
+    protected Icon icon;
     public String variants;
 
     public int[] fgcolor;
@@ -81,7 +82,6 @@ public abstract class TerrainI implements UTerrain, Entity, Cloneable, UAnimator
         icon = new Icon(glyph,fgColor,bgColor);
     }
 
-    public Icon icon() { return icon; }
     public String[] UIdetails(String context) { return null; }
 
     public void becomeReal(UCell c) {
@@ -104,13 +104,10 @@ public abstract class TerrainI implements UTerrain, Entity, Cloneable, UAnimator
     }
 
     public float sunvis() { return sunvis; }
-    public char glyph() {
-        return glyph;
-    }
 
     public char glyph(int x, int y) {
         if (variants == null)
-            return glyph();
+            return getGlyph();
         int seed = (x * y * 19 + 1883) / 74;
         int period = variants.length();
         return variants.charAt(seed % period);
@@ -143,7 +140,7 @@ public abstract class TerrainI implements UTerrain, Entity, Cloneable, UAnimator
     }
 
     public void walkedOnBy(UActor actor, UCell cell) {
-        if (actor.isPlayer()) {
+        if (actor instanceof UPlayer) {
             printScroll(walkmsg, cell);
         }
     }
@@ -189,6 +186,8 @@ public abstract class TerrainI implements UTerrain, Entity, Cloneable, UAnimator
     public UColor fgColor() { return fgColor; }
     public UColor fgColorBuffer() { return fgColorBuffer; }
 
-    public String name() { return name; }
+    public String getName() { return name; }
+    public Icon getIcon() { return icon; }
+    public char getGlyph() { return glyph; }
 
 }

--- a/src/main/java/ure/terrain/UTerrain.java
+++ b/src/main/java/ure/terrain/UTerrain.java
@@ -17,9 +17,9 @@ public interface UTerrain {
     boolean breaksLatch();
     void initialize();
     void becomeReal(UCell c);
-    char glyph();
+    char getGlyph();
     char glyph(int x, int y);
-    Icon icon();
+    Icon getIcon();
     String[] UIdetails(String context);
     int glyphOffsetX();
     int glyphOffsetY();
@@ -37,6 +37,6 @@ public interface UTerrain {
     UColor bgColorBuffer();
     UColor fgColor();
     UColor fgColorBuffer();
-    String name();
+    String getName();
     String bonkmsg();
 }

--- a/src/main/java/ure/things/Lightsource.java
+++ b/src/main/java/ure/things/Lightsource.java
@@ -36,7 +36,7 @@ public class Lightsource extends ThingI implements UThing {
     void makeLight() {
         if (lightcolorUseGlyph) {
             SetupColors();
-            light = new ULight(glyphColor, lightrange, lightfalloff);
+            light = new ULight(getGlyphColor(), lightrange, lightfalloff);
         } else {
             light = new ULight(new UColor(lightcolor[0], lightcolor[1], lightcolor[2]), lightrange, lightfalloff);
         }
@@ -46,7 +46,7 @@ public class Lightsource extends ThingI implements UThing {
     }
 
     public boolean on() {
-        if (location == null)
+        if (getLocation() == null)
             return false;
         if (light == null)
             makeLight();
@@ -75,8 +75,8 @@ public class Lightsource extends ThingI implements UThing {
 
     @Override
     public void leaveCurrentLocation() {
-        if (location != null) {
-            if (location.containerType() == UContainer.TYPE_CELL) {
+        if (getLocation() != null) {
+            if (getLocation().containerType() == UContainer.TYPE_CELL) {
                 if (on()) {
                     light.removeFromArea();
                 }
@@ -88,7 +88,7 @@ public class Lightsource extends ThingI implements UThing {
     public void turnOn() {
         if (!on()) {
             on = true;
-            if (location != null) {
+            if (getLocation() != null) {
                 light.moveTo(area(), areaX(), areaY());
             }
         }

--- a/src/main/java/ure/things/ThingDeco.java
+++ b/src/main/java/ure/things/ThingDeco.java
@@ -17,19 +17,17 @@ public class ThingDeco implements UThing, Interactable {
         thing = realThing;
     }
 
-    public boolean isActor() { return thing.isActor(); }
-    public boolean isPlayer() { return thing.isPlayer(); }
     public void initialize() { thing.initialize(); }
     public void setDisplayFields(String thename, char theglyph, UColor thecolor, boolean addOutline) { thing.setDisplayFields(thename, theglyph, thecolor, addOutline); }
-    public String name() { return thing.name(); }
-    public String iname() { return thing.iname(); }
-    public String dname() { return thing.dname(); }
-    public String dnamec() { return thing.dnamec(); }
-    public String plural() { return thing.plural(); }
+    public String getName() { return thing.getName(); }
+    public String getIname() { return thing.getIname(); }
+    public String getDname() { return thing.getDname(); }
+    public String getDnamec() { return thing.getDnamec(); }
+    public String getPlural() { return thing.getPlural(); }
     public String getMsg(UActor actor) { return thing.getMsg(actor); }
     public String walkMsg(UActor actor) { return thing.walkMsg(actor); }
-    public char glyph() { return thing.glyph(); }
-    public Icon icon() { return thing.icon(); }
+    public char getGlyph() { return thing.getGlyph(); }
+    public Icon getIcon() { return thing.getIcon(); }
     public String[] UIdetails(String context) { return thing.UIdetails(context); }
     public int glyphOffsetX() { return thing.glyphOffsetX(); }
     public int glyphOffsetY() { return thing.glyphOffsetY(); }
@@ -39,11 +37,11 @@ public class ThingDeco implements UThing, Interactable {
     public void moveToCell(UArea area, int x, int y) { thing.moveToCell(area, x ,y); }
     public void moveTo(UContainer container) { thing.moveTo(container); }
     public void leaveCurrentLocation() { thing.leaveCurrentLocation(); }
-    public UContainer location() { return thing.location(); }
+    public UContainer getLocation() { return thing.getLocation(); }
     public void addThing(UThing thething) { thing.addThing(thething); }
     public void removeThing(UThing thething) { thing.removeThing(thething); }
     public Iterator<UThing> iterator() { return thing.iterator(); }
-    public UCollection contents() { return thing.contents(); }
+    public UCollection getContents() { return thing.getContents(); }
     public boolean willAcceptThing(UThing thething) { return thing.willAcceptThing(thething); }
     public int areaX() { return thing.areaX(); }
     public int areaY() { return thing.areaY(); }

--- a/src/main/java/ure/things/ThingI.java
+++ b/src/main/java/ure/things/ThingI.java
@@ -1,5 +1,7 @@
 package ure.things;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import ure.actors.UPlayer;
 import ure.sys.Entity;
 import ure.sys.Injector;
 import ure.sys.UCommander;
@@ -25,48 +27,42 @@ import java.util.Random;
 public abstract class ThingI implements UThing, UContainer, Entity, Interactable, Cloneable {
 
     @Inject
+    @JsonIgnore
     public UCommander commander;
 
-    public String name;
-    public String iname;
-    public String dname;
-    public String plural;
-    public String type;
-    public char glyph;
-    public String description = "A thing.";
-    public int weight;
-    public boolean movable = true;
-    public int value;
-    public int[] color;
-    public int[] colorvariance = new int[]{0,0,0};
-    public String getFailMsg = "You can't pick that up.";
+    protected String name;
+    protected String iname;
+    protected String dname;
+    protected String plural;
+    protected String type;
+    protected char glyph;
+    protected String description = "A thing.";
+    protected int weight;
+    protected boolean movable = true;
+    protected int value;
+    protected int[] color;
+    protected int[] colorvariance = new int[]{0,0,0};
+    protected String getFailMsg = "You can't pick that up.";
 
     public static final String TYPE = "";
 
-    UColor glyphColor;
-    public boolean glyphOutline = false;
-    Icon icon;
+    protected UColor glyphColor;
+    protected boolean glyphOutline = false;
+    protected Icon icon;
 
     protected UContainer location;  // What container am I in?
     protected UCollection contents; // What's inside me?
-
-    public static boolean isActor = false;
 
     public ThingI() {
         Injector.getAppComponent().inject(this);
     }
 
-    public boolean isActor() {
-        return false;
-    }
-    public boolean isPlayer() { return false; }
-
     public void initialize() {
-        contents = new UCollection(this);
-        if (glyphColor == null && color != null) {
+        setContents(new UCollection(this));
+        if (getGlyphColor() == null && getColor() != null) {
             SetupColors();
         }
-        icon = new Icon(glyph, glyphColor, null);
+        setIcon(new Icon(getGlyph(), getGlyphColor(), null));
     }
 
     public void SetupColors() {
@@ -76,39 +72,16 @@ public abstract class ThingI implements UThing, UContainer, Entity, Interactable
             if (colorvariance[i] > 0)
                 thecolor[i] += (random.nextInt(colorvariance[i]) - colorvariance[i]/2);
         }
-        glyphColor = new UColor(thecolor[0],thecolor[1],thecolor[2]);
+        setGlyphColor(new UColor(thecolor[0],thecolor[1],thecolor[2]));
     }
 
     public void setDisplayFields(String thename, char theglyph, UColor thecolor, boolean addOutline) {
-        name = thename;
-        glyph = theglyph;
-        glyphColor = thecolor;
-        glyphOutline = addOutline;
+        setName(thename);
+        setGlyph(theglyph);
+        setGlyphColor(thecolor);
+        setGlyphOutline(addOutline);
     }
 
-    public String iname() {
-        if (iname != null && iname != "")
-            return iname;
-        return "a " + name;
-    }
-    public String dname() {
-        return "the " + name;
-    }
-    public String dnamec() {
-        return "The " + name;
-    }
-    public String plural() {
-        if (plural != null && plural != "")
-            return plural;
-        char last = name.charAt(name.length()-1);
-        if (last == 's')
-            return name + "es";
-        return name + "s";
-    }
-
-    public char glyph() {
-        return glyph;
-    }
     public int glyphOffsetX() { return 0; }
     public int glyphOffsetY() { return 0; }
 
@@ -116,24 +89,22 @@ public abstract class ThingI implements UThing, UContainer, Entity, Interactable
         return glyphColor;
     }
 
-    public Icon icon() { return icon; }
+    public Icon icon() { return getIcon(); }
 
     public String[] UIdetails(String context) {
         return new String[]{
-                "Weight " + Integer.toString(weight),
-                "Value " + Integer.toString(value)
+                "Weight " + Integer.toString(getWeight()),
+                "Value " + Integer.toString(getValue())
         };
     }
 
     public boolean drawGlyphOutline() {
-        if (glyphOutline)
+        if (isGlyphOutline())
             return true;
         if (commander.config.isOutlineThings())
             return true;
         return false;
     }
-
-    public UContainer location() { return location; }
 
     public void moveToCell(int x, int y) {
         moveToCell(area(), x, y);
@@ -149,44 +120,43 @@ public abstract class ThingI implements UThing, UContainer, Entity, Interactable
     public void moveTo(UContainer container) {
         leaveCurrentLocation();
         container.addThing(this);
-        this.location = container;
+        this.setLocation(container);
     }
 
     public void leaveCurrentLocation() {
-        if (location != null) {
-            location.removeThing(this);
+        if (getLocation() != null) {
+            getLocation().removeThing(this);
         }
-        this.location = null;
+        this.setLocation(null);
     }
 
     public void addThing(UThing thing) {
-        contents.add(thing);
+        getContents().add(thing);
     }
     public void removeThing(UThing thing) {
-        contents.remove(thing);
+        getContents().remove(thing);
     }
     public Iterator<UThing> iterator() {
-        return contents.iterator();
+        return getContents().iterator();
     }
-    public UCollection contents() { return contents; }
 
     public int containerType() { return UContainer.TYPE_THING; }
     public boolean willAcceptThing(UThing thing) {
         return false;
     }
 
-    public int areaX() { return location.areaX(); }
-    public int areaY() { return location.areaY(); }
+    public int areaX() { return getLocation().areaX(); }
+    public int areaY() { return getLocation().areaY(); }
 
     public int cameraX(UCamera camera) {
-        return location.areaX() - camera.leftEdge;
+        return getLocation().areaX() - camera.leftEdge;
     }
     public int cameraY(UCamera camera) {
-        return location.areaY() - camera.topEdge;
+        return getLocation().areaY() - camera.topEdge;
     }
     public UArea area() {
-        if (location != null)
-            return location.area();
+        if (getLocation() != null)
+            return getLocation().area();
         return null;
     }
 
@@ -200,9 +170,9 @@ public abstract class ThingI implements UThing, UContainer, Entity, Interactable
     }
 
     public boolean tryGetBy(UActor actor) {
-        if (!movable) {
-            if (actor.isPlayer())
-                commander.printScroll(getFailMsg);
+        if (!isMovable()) {
+            if (actor instanceof UPlayer)
+                commander.printScroll(getGetFailMsg());
             return false;
         }
         return true;
@@ -224,17 +194,17 @@ public abstract class ThingI implements UThing, UContainer, Entity, Interactable
     }
 
     public String getMsg(UActor actor) {
-        return description;
+        return getDescription();
     }
 
-    public String walkMsg(UActor actor) { return "You see " + iname() + "."; }
+    public String walkMsg(UActor actor) { return "You see " + getIname() + "."; }
 
     //The camera class will call this, and tell where in screen coords to draw it.
     // TODO: Things should probably not be tied directly to the rendering system.  Ideally they would just be part of the data layer, not the presentation layer
     public void render(URenderer renderer, int x, int y, UColor light, float vis){
         int xoff = glyphOffsetX();
         int yoff = glyphOffsetY();
-        char icon = this.glyph();
+        char icon = getGlyph();
         UColor color = new UColor(this.getGlyphColor());
         if (this.drawGlyphOutline()) {
             renderer.drawGlyphOutline(icon, x, y, UColor.COLOR_BLACK, xoff, yoff);
@@ -247,5 +217,156 @@ public abstract class ThingI implements UThing, UContainer, Entity, Interactable
         commander.printScrollIfSeen(this, text);
     }
 
-    public String name() { return name; }
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getIname() {
+        if (iname != null && !iname.isEmpty())
+            return iname;
+        return "a " + getName();
+    }
+
+    public void setIname(String iname) {
+        this.iname = iname;
+    }
+
+    public String getDname() {
+        if (dname != null && !dname.isEmpty())
+            return dname;
+        return "the " + getName();
+    }
+
+    public void setDname(String dname) {
+        this.dname = dname;
+    }
+
+    public String getDnamec() {
+        return "The " + getName();
+    }
+
+    public String getPlural() {
+        if (plural != null && !plural.isEmpty())
+            return plural;
+        char last = getName().charAt(getName().length()-1);
+        if (last == 's')
+            return getName() + "es";
+        return getName() + "s";
+    }
+
+    public void setPlural(String plural) {
+        this.plural = plural;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public char getGlyph() {
+        return glyph;
+    }
+
+    public void setGlyph(char glyph) {
+        this.glyph = glyph;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public int getWeight() {
+        return weight;
+    }
+
+    public void setWeight(int weight) {
+        this.weight = weight;
+    }
+
+    public boolean isMovable() {
+        return movable;
+    }
+
+    public void setMovable(boolean movable) {
+        this.movable = movable;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+
+    public int[] getColor() {
+        return color;
+    }
+
+    public void setColor(int[] color) {
+        this.color = color;
+    }
+
+    public int[] getColorvariance() {
+        return colorvariance;
+    }
+
+    public void setColorvariance(int[] colorvariance) {
+        this.colorvariance = colorvariance;
+    }
+
+    public String getGetFailMsg() {
+        return getFailMsg;
+    }
+
+    public void setGetFailMsg(String getFailMsg) {
+        this.getFailMsg = getFailMsg;
+    }
+
+    public void setGlyphColor(UColor glyphColor) {
+        this.glyphColor = glyphColor;
+    }
+
+    public boolean isGlyphOutline() {
+        return glyphOutline;
+    }
+
+    public void setGlyphOutline(boolean glyphOutline) {
+        this.glyphOutline = glyphOutline;
+    }
+
+    public Icon getIcon() {
+        return icon;
+    }
+
+    public void setIcon(Icon icon) {
+        this.icon = icon;
+    }
+
+    public UContainer getLocation() {
+        return location;
+    }
+
+    public void setLocation(UContainer location) {
+        this.location = location;
+    }
+
+    public UCollection getContents() {
+        return contents;
+    }
+
+    public void setContents(UCollection contents) {
+        this.contents = contents;
+    }
 }

--- a/src/main/java/ure/things/UCollection.java
+++ b/src/main/java/ure/things/UCollection.java
@@ -28,7 +28,7 @@ public class UCollection {
     }
 
     public void add(UThing thing) {
-        if (thing.isActor())
+        if (thing instanceof UActor)
             actors.add((UActor)thing);
         else
             things.add(thing);

--- a/src/main/java/ure/things/UThing.java
+++ b/src/main/java/ure/things/UThing.java
@@ -1,6 +1,5 @@
 package ure.things;
 
-import ure.actions.Interactable;
 import ure.math.UColor;
 import ure.areas.UArea;
 import ure.actors.UActor;
@@ -10,16 +9,8 @@ import ure.ui.Icon;
 import java.util.Iterator;
 
 public interface UThing  {
-    boolean isActor();
-    boolean isPlayer();
     void initialize();
     void setDisplayFields(String thename, char theglyph, UColor thecolor, boolean addOutline);
-    String iname();
-    String dname();
-    String dnamec();
-    String plural();
-    char glyph();
-    Icon icon();
     String[] UIdetails(String context);
     int glyphOffsetX();
     int glyphOffsetY();
@@ -28,11 +19,9 @@ public interface UThing  {
     void moveToCell(int x, int y);
     void moveToCell(UArea area, int x, int y);
     void moveTo(UContainer container);
-    UContainer location();
     void leaveCurrentLocation();
     void addThing(UThing thing);
     void removeThing(UThing thing);
-    UCollection contents();
     Iterator<UThing> iterator();
     boolean willAcceptThing(UThing thing);
     int areaX();
@@ -47,5 +36,13 @@ public interface UThing  {
     String walkMsg(UActor actor);
     void render(URenderer renderer, int x, int y, UColor light, float vis);
     void emote(String text);
-    String name();
+    String getName();
+    String getIname();
+    String getDname();
+    String getDnamec();
+    String getPlural();
+    Icon getIcon();
+    UContainer getLocation();
+    char getGlyph();
+    UCollection getContents();
 }

--- a/src/main/java/ure/things/UThingCzar.java
+++ b/src/main/java/ure/things/UThingCzar.java
@@ -26,7 +26,7 @@ public class UThingCzar {
             ThingI[] thingObjs = objectMapper.readValue(inputStream, ThingI[].class);
             for (ThingI thing: thingObjs) {
                 thing.initialize();
-                thingsByName.put(thing.name, thing);
+                thingsByName.put(thing.getName(), thing);
             }
         } catch (IOException io) {
             io.printStackTrace();

--- a/src/main/java/ure/ui/ULensPanel.java
+++ b/src/main/java/ure/ui/ULensPanel.java
@@ -77,21 +77,21 @@ public class ULensPanel extends View {
             return;
         UTerrain t = camera.terrainAt(x,y);
         if (t != null) {
-            renderer.drawString(xpos + padX + renderer.glyphWidth()*2, ypos + padY, commander.config.getTextColor(), t.name());
-            t.icon().draw(renderer, xpos + padX, ypos + padY);
+            renderer.drawString(xpos + padX + renderer.glyphWidth()*2, ypos + padY, commander.config.getTextColor(), t.getName());
+            t.getIcon().draw(renderer, xpos + padX, ypos + padY);
         }
         UCell cell = camera.area.cellAt(x+camera.leftEdge,y+camera.topEdge);
         if (cell != null) {
             UThing thing = cell.topThingAt();
             if (thing != null) {
-                thing.icon().draw(renderer, xpos+padX, ypos+padY+renderer.glyphHeight());
-                renderer.drawString(xpos + padX + renderer.glyphWidth()*2, ypos + padY + renderer.glyphHeight(), commander.config.getTextColor(), thing.iname());
+                thing.getIcon().draw(renderer, xpos+padX, ypos+padY+renderer.glyphHeight());
+                renderer.drawString(xpos + padX + renderer.glyphWidth()*2, ypos + padY + renderer.glyphHeight(), commander.config.getTextColor(), thing.getIname());
 
             }
             UActor actor = cell.actorAt();
             if (actor != null) {
                 actor.icon().draw(renderer, xpos+padX, ypos+padY+renderer.glyphHeight()*2);
-                renderer.drawString(xpos + padX + renderer.glyphWidth()*2, ypos + padY + commander.config.getGlyphHeight() * 2, commander.config.getTextColor(), actor.iname());
+                renderer.drawString(xpos + padX + renderer.glyphWidth()*2, ypos + padY + commander.config.getGlyphHeight() * 2, commander.config.getTextColor(), actor.getIname());
             }
         }
     }

--- a/src/main/java/ure/ui/modals/UModalEntityPick.java
+++ b/src/main/java/ure/ui/modals/UModalEntityPick.java
@@ -29,8 +29,8 @@ public class UModalEntityPick extends UModal {
         showDetail =  _showDetail;
         int width = 0;
         for (Entity entity : entities) {
-            if (entity.name().length() > width)
-                width = entity.name().length();
+            if (entity.getName().length() > width)
+                width = entity.getName().length();
         }
         textWidth = width;
         if (showDetail)
@@ -50,12 +50,12 @@ public class UModalEntityPick extends UModal {
             if (y == selection) {
                 renderer.drawRect(gw()+xpos,(y+2)*gh()+ypos, textWidth*gw(), gh(), commander.config.getHiliteColor());
             }
-            drawIcon(renderer, entity.icon(), 1, y + 2);
-            drawString(renderer, entity.name(), 3, y + 2);
+            drawIcon(renderer, entity.getIcon(), 1, y + 2);
+            drawString(renderer, entity.getName(), 3, y + 2);
             y++;
         }
         if (showDetail) {
-            drawString(renderer, entities.get(selection).name(), 4+textWidth, 2);
+            drawString(renderer, entities.get(selection).getName(), 4+textWidth, 2);
             String[] details = entities.get(selection).UIdetails(callbackContext);
             int linepos = 4;
             for (String line : details) {


### PR DESCRIPTION
Jackson expects fields we want to serialize to have getters with the standard naming convention.  So I'm working my way through the objects we'll need to serialize when we serialize a `UArea` and changing the fields to protected access (so subclasses will still have direct access) and renaming the getters to match the Java convention that Jackson expects.

This is a small step towards making serialization work, but it's a huge change set and I wanted to make sure this is what you wanted with respect to member variable access before I do the rest of the work.  Don't feel compelled to merge this if it makes you unhappy.  There are other ways to deal with the Jackson issues:

* annotating all the getters with @JsonGetter("fieldName")
* figuring out why telling Jackson to serialize all fields blows up

Based on our conversation though it sounded like you wanted to standardize getter/setters to use the standard Java convention, and that's what most of this is.  If I misinterpreted or you have second thoughts after looking at this PR though that's fine.  Let me know what works best for you and I'll make it so.

Another thing I noticed as I was doing this was that we have fields/methods for determining if a thing is an actor or a player.  I stripped that out in favor of doing inheritance checks (`thing instanceof UActor`, etc).  If you had special reasons for the other system let me know and I'll leave it alone.
