### PR TITLE
Add guava event bus and PlayerChangedAreaEvent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     compile "org.joml:joml:1.9.9"
     compile "commons-io:commons-io:2.6"
     compile "commons-lang:commons-lang:2.6"
+    compile 'com.google.guava:guava:25.1-jre'
 
     compile "org.lwjgl:lwjgl:${lwjglVersion}"
     compile "org.lwjgl:lwjgl:${lwjglVersion}:natives-linux"

--- a/src/main/java/ure/events/PlayerChangedAreaEvent.java
+++ b/src/main/java/ure/events/PlayerChangedAreaEvent.java
@@ -1,0 +1,19 @@
+package ure.events;
+
+import ure.actors.UPlayer;
+import ure.areas.UArea;
+import ure.terrain.Stairs;
+
+public class PlayerChangedAreaEvent {
+    public UPlayer player;
+    public Stairs stairs;
+    public UArea sourceArea;
+    public UArea destArea;
+
+    public PlayerChangedAreaEvent(UPlayer player, Stairs stairs, UArea sourceArea, UArea destArea) {
+        this.player = player;
+        this.stairs = stairs;
+        this.sourceArea = sourceArea;
+        this.destArea = destArea;
+    }
+}

--- a/src/main/java/ure/sys/dagger/AppComponent.java
+++ b/src/main/java/ure/sys/dagger/AppComponent.java
@@ -9,6 +9,7 @@ import ure.actors.UActorCzar;
 import ure.behaviors.UBehavior;
 import ure.commands.UCommand;
 import ure.examplegame.ExampleGame;
+import ure.terrain.Stairs;
 import ure.terrain.UTerrain;
 import ure.terrain.UTerrainCzar;
 import ure.things.UThing;
@@ -60,4 +61,5 @@ public interface AppComponent {
     void inject(URegion reg);
     void inject(UPanel pan);
     void inject(USpeaker speak);
+    void inject(Stairs stairs);
 }

--- a/src/main/java/ure/sys/dagger/AppModule.java
+++ b/src/main/java/ure/sys/dagger/AppModule.java
@@ -2,6 +2,7 @@ package ure.sys.dagger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.eventbus.EventBus;
 import dagger.Module;
 import dagger.Provides;
 import ure.areas.LandscaperDeserializer;
@@ -80,5 +81,11 @@ public class AppModule {
     public UCartographer providesCartographer() {
         UCartographer cartographer = new UCartographer();
         return cartographer;
+    }
+
+    @Provides
+    @Singleton
+    public EventBus providesEventBus() {
+        return new EventBus();
     }
 }

--- a/src/main/java/ure/terrain/Stairs.java
+++ b/src/main/java/ure/terrain/Stairs.java
@@ -1,13 +1,17 @@
 package ure.terrain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.eventbus.EventBus;
 import ure.actors.UPlayer;
 import ure.areas.UArea;
-import ure.areas.UCartographer;
 import ure.areas.UCell;
 import ure.actors.UActor;
+import ure.events.PlayerChangedAreaEvent;
+import ure.sys.Injector;
 import ure.ui.modals.HearModalChoices;
 import ure.ui.modals.UModalChoices;
 
+import javax.inject.Inject;
 import java.util.ArrayList;
 
 /**
@@ -28,6 +32,14 @@ public class Stairs extends UTerrain implements HearModalChoices {
     protected int destY;
     protected boolean onstep = true;
     protected boolean confirm = true;
+
+    @Inject
+    @JsonIgnore
+    EventBus bus;
+
+    public Stairs() {
+        Injector.getAppComponent().inject(this); // This will inject superclass fields too, so no need to call super()
+    }
 
     public String getLabel() {
         /**
@@ -55,8 +67,7 @@ public class Stairs extends UTerrain implements HearModalChoices {
         }
         actor.moveToCell(destarea, dest.areaX(), dest.areaY());
         if (actor instanceof UPlayer) {
-            commander.cartographer.playerLeftArea((UPlayer)actor, sourcearea);
-            commander.playerChangedArea(sourcearea, destarea);
+            bus.post(new PlayerChangedAreaEvent((UPlayer)actor, this, sourcearea, destarea));
         }
     }
 


### PR DESCRIPTION
This is a very simple example of using the Guava event bus to deliver events that more than one party is interested in.  This might be a pattern worth considering for actions, or it might be more complication than you want.  The nice thing about delivering info this way is that you don't have to know who to send it to,  you just throw it out there on the bus and whoever needs it picks it up, which means we wouldn't have to maintain refs to those objects and they wouldn't be a concern when serializing/deserializing.

I thought it might be cool to use this mechanism to signal when areas are loaded and other stuff like that, but it gets complicated because that stuff is happening on another thread.  We would need a system similar to the keypress buffer to store and process events for things that happened on other threads.